### PR TITLE
include graphicx package

### DIFF
--- a/wbh.tex
+++ b/wbh.tex
@@ -49,6 +49,7 @@ $endif$
 \usepackage[right]{eurosym}
 \usepackage[subfigure,titles]{tocloft}
 \usepackage{helvet}
+\usepackage{graphicx}
 
 $if(tables)$
 	\usepackage{longtable,booktabs} % This two Packages are needet for Pandoc Table support. Issue is opened: https://github.com/jgm/pandoc/issues/1023
@@ -137,7 +138,7 @@ $endif$
 \renewenvironment{quote}{\begin{customblockquote}\list{}{\rightmargin=0em\leftmargin=0em}%
 \item\relax\color{blockquote-text}\ignorespaces}{\unskip\unskip\endlist\end{customblockquote}}
 
-% Syntax Highligting with colors
+% Syntax Highlighting with colors
 % -----------------------------------------------------------------
 $if(highlighting-macros)$
 $highlighting-macros$


### PR DESCRIPTION
Compiling of Test Markdown File failed with:
```
❯ pandoc -s --template=wbh.tex -o output.pdf test.md
Error producing PDF.
! Undefined control sequence.
l.142       \includegraphics
```
on Mac.

Solution is to explicitly include the **graphicx** package.