### PR TITLE
[DRAFT] adding draft first version

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Im Folgenden sind die einzelnen Variablen und Schalter erläutert. Alle Optional
 | lot           | Verzeichnis der Tabellen                              | ja       | true / false  |
 | lof           | Liste der Figuren/Abbildungen                         | ja       | true / false  |
 | skipfirstpage | Zählt die Titleseite nicht mit                        | ja       | true          |
+| draft	| Draft Wasserzeichen | ja | false |
+| draft.text | Wasserzeichentext | ja | Draft \today |
 
 ## ToDo
 

--- a/wbh.tex
+++ b/wbh.tex
@@ -76,6 +76,14 @@ $if(graphics)$
 \makeatother
 $endif$
 
+$if(draft)$
+\usepackage{blindtext}
+\usepackage{draftwatermark}
+\SetWatermarkLightness{ 0.9 }
+\SetWatermarkText{$if(draft.text)$$draft.text$$else$Draft$endif$}
+\SetWatermarkScale{5}
+$endif$
+
 % Support hyperref with colorisation
 % -------------------------------------------------------------------------
 \usepackage{xcolor}


### PR DESCRIPTION
Adding a switch to print "Draft" Watermark on the Page. That is Usefull to be not confused by different versions of the PDF. Scince you generate the final version, remove the draft and you never send the wrong versions.


Actual issues:
- [ ] In draft mode you can't mark text!
- [ ] The size is not correct on each page...