### PR TITLE
Einstellbare Seitenränder für Titelseite

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Im Folgenden sind die einzelnen Variablen und Schalter erläutert. Alle Optional
 | seite.rand_unten   | Seitenrand unten                                      | ja       | 20mm          |
 | seite.rand_rechts  | Seitenrand rechts                                     | ja       | 40mm          |
 | seite.rand_links   | Seitenrand links                                      | ja       | 30mm          |
+| titelseite.rand_oben    | Seitenrand Titelseite oben                                       | ja       | 20mm          |
+| titelseite.rand_unten   | Seitenrand Titelseite unten                                      | ja       | 20mm          |
+| titelseite.rand_rechts  | Seitenrand Titelseite rechts                                     | ja       | 20mm          |
+| titelseite.rand_links   | Seitenrand Titelseite links                                      | ja       | 20mm          |
 
 ### Aufgabenstellung mit einbinden
 

--- a/wbh.tex
+++ b/wbh.tex
@@ -359,7 +359,6 @@ $endif$
 % -------------------------------------------------------------
 % Titelseite
 % -------------------------------------------------------------
-%\thispagestyle{empty}
 \begin{titlepage}
 % Ränder für Titleseite werden neugesetzt
 % Links:            2cm 
@@ -446,7 +445,7 @@ $if(hochschule.adresse)$
 $endif$
 \end{center}
 \end{titlepage}
-\restoregeometry
+\restoregeometry    % Zurück auf Standard Page Geometry
 \pagebreak
 
 % -------------------------------------------------------------

--- a/wbh.tex
+++ b/wbh.tex
@@ -359,7 +359,13 @@ $endif$
 % -------------------------------------------------------------
 % Titelseite
 % -------------------------------------------------------------
-\thispagestyle{empty}
+%\thispagestyle{empty}
+\begin{titlepage}
+% Ränder für Titleseite werden neugesetzt
+% Links:            2cm 
+% Oben und unten:   2cm
+% Rechts:           2cm 
+\newgeometry{top=$if(titelseite.rand_oben)$$titelseite.rand_oben$$else$20mm$endif$, left=$if(titelseite.rand_links)$$titelseite.rand_links$$else$20mm$endif$, right=$if(titelseite.rand_rechts)$$titelseite.rand_rechts$$else$20mm$endif$, bottom=$if(titelseite.rand_unten)$$titelseite.rand_unten$$else$20mm$endif$}
 \begin{center}
 $if(logo)$ 
     \includegraphics[max width=\textwidth]{$logo$}\\
@@ -439,6 +445,8 @@ $if(hochschule.adresse)$
     $if(hochschule.name)$$hochschule.name$, $endif$$hochschule.adresse$
 $endif$
 \end{center}
+\end{titlepage}
+\restoregeometry
 \pagebreak
 
 % -------------------------------------------------------------


### PR DESCRIPTION
- neue Variablen für Titelseitenränder mit denen man die Titelseite symmetrisch gestalten kann.
- Default werte 


|   Variable             |                     Beschreibung                      | Optional |    default    |
|:---------------------- |:----------------------------------------------------- |:-------- |:------------- |
| titelseite.rand_oben    | Seitenrand Titelseite oben                                       | ja       | 20mm          |
| titelseite.rand_unten   | Seitenrand Titelseite unten                                      | ja       | 20mm          |
| titelseite.rand_rechts  | Seitenrand Titelseite rechts                                     | ja       | 20mm          |
| titelseite.rand_links   | Seitenrand Titelseite links                                      | ja       | 20mm          |