### PR TITLE
Fix broken acronym plurals m( - add more info to Readme.md and also 

### DIFF
--- a/Beispiel/Makefile
+++ b/Beispiel/Makefile
@@ -4,3 +4,9 @@ wbh:
 	# Entferne die Kommentare um das erstellte PDF mit mupdf anzuzeigen
 	#mupdf beispiel.pdf
 
+wbh_acronym:
+
+	pandoc -s --template="../wbh.tex" -o beispiel.tex --metadata-file=acronyms.yaml beispiel.md	
+	pandoc -s --template="../wbh.tex" -o beispiel.pdf --metadata-file=acronyms.yaml beispiel.md
+	# Entferne die Kommentare um das erstellte PDF mit mupdf anzuzeigen
+	#mupdf beispiel.pdf

--- a/Beispiel/acronyms.yaml
+++ b/Beispiel/acronyms.yaml
@@ -1,0 +1,17 @@
+acronym:
+    longest: ECTS
+    list:
+        -   id: dau
+            short: DAU
+            shortplural: DAUs
+            long: Dümmster anzunehmender User
+            longplural: Dümmste anzunehmende User
+        -   id: ects
+            short: ECTS
+            long: European Credit Transfer System
+        -   id: ssd
+            short: SSD
+            long: Solid state Disk
+        -   id: wbh
+            short: WBH
+            long: Wilhelm Büchner Hochschule

--- a/Beispiel/beispiel.md
+++ b/Beispiel/beispiel.md
@@ -169,3 +169,57 @@ De: \qty[locale = DE]{6.789}{\metre} \\
 Us: \qty[locale = US]{6.789}{\metre} 
 \end{aligned}
 $$
+
+# Akronyme und Zitate
+
+## Akronyme
+
+Das LaTeX Paket *acronyms* erlaubt das definieren von Akronymen. Das geniale an dem Paket ist, dass jede Abkürzung, oder Akronym, bei der ersten Verwendung ausgeschreiben wird. Z.b. wird aus `\ac{dau}` bei der ersten Verwendung `Dümmster anzunehmender User (DAU)` und ab der zweiten Verwendung eben nur noch `DAU` als Abkürzung.
+
+Um die Akronyme zu definieren ist eine Datei `acronyms.yaml` notwendig, die hier auch im Beispiel Ordner liegt.
+
+Die Datei sieht ungefähr so aus:
+
+```
+acronym:
+    longest: ECTS
+    list:
+        -   id: dau
+            short: DAU
+            shortplural: DAUs
+            long: Dümmster anzunehmender User
+            longplural: Dümmste anzunehmende User
+        -   id: ects
+            short: ECTS
+            long: European Credit Transfer System
+        -   id: ssd
+            short: SSD
+            long: Solid state Disk
+        -   id: wbh
+            short: WBH
+            long: Wilhelm Büchner Hochschule
+
+```
+
+Es können auch Plurale genutzt werden.
+
+Wichtig ist, für die Spaltenbildung im Abkürzungsverzeichnis, dass die längste Abkürzung anzugeben.
+
+Die Acronyme können dann wie folgt eingesetzt werden:
+
+
+| Code     |  Erklärung          | Ergebnis                |
+| -------- | ------------------- | ----------------------- |
+| `\ac{dau}  `|  Abkürzung ausgeschrieben und kurz in Klammern  | \ac{dau}   |
+| `\acf{dau} `|  Erzwinge `\ac{dau}`                            | \acf{dau}  |
+| `\acl{dau} `|  Nur Langform                                   | \acl{dau}  |
+| `\acs{dau} `|  Nur Kurzform                                   | \acs{dau}  |
+| `\aclp{dau} `|  Langform Plural                               | \aclp{dau} |
+| `\acsp{dau}`|  Kurzform Plural                                | \acsp{dau} |
+
+
+
+
+## Zitate
+
+Todo

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Eine Range kann durch `{x-y}` angegeben werden.
 ```
 Dabei unbedingt die einfachen Anführungszeichen drin lassen. Eine Range kann leider nicht angegeben
 
-Weitere Hinweise stehen in der (Dokumentation)[https://texdoc.org/serve/pdfpages.pdf/0] des LaTeX packages `pdfpages`
+Weitere Hinweise stehen in der [Dokumentation](https://texdoc.org/serve/pdfpages.pdf/0) des LaTeX packages `pdfpages`
 
 
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ acronym:
             longplural: International Mobile Subscriber Identities                
 ```
 
+Die  `acronyms.yaml` wird Pandoc mittels des Commandline Switches `--metadata-file=acronyms.yaml` bekannt gemacht. Im Beispiel [Makefile](Beispiel/Makefile) ist ein Beispiel Target `wbh_acronyms` welches die Verwendung zeigt.
+
 Verwendung im Markdown dann mit
 
 ```
@@ -217,6 +219,7 @@ Verwendung im Markdown dann mit
 Bei den Pluralen ist zu beachten, dass wenn kein Plural definiert ist (siehe `acronyms.yaml` Beispiel), dass einfach ein "s" angehangen wird.
 
 Für mehr Info über Acronyme, siehe [Dokumentation LaTeX acronym Package](https://mirror.clientvps.com/CTAN/macros/latex/contrib/acronym/acronym.pdf) 
+
 
 
 

--- a/wbh.tex
+++ b/wbh.tex
@@ -108,12 +108,12 @@ $if(assignment.fillform)$
 \begin{tikzpicture}[remember picture, overlay, x=1mm,y=1mm,%
 mybox/.style={rectangle,minimum width=56mm, draw opacity=0.0, line width=0,  minimum height=8mm, align=left,text width=56mm},%
 info/.style={mybox,draw=black,align=left}]
-\node at (34,-34) [info] {$student.firstname$};
-\node at (95,-34) [info] {$student.lastname$};
-\node at (34,-47) [info] {$student.strasse$};
-\node at (95,-47) [info] {$student.ort$}; 
-\node at (34,-59) [info] {$student.matrikelnr$};
-\node at (95,-59) [info] {$studium.studiengangnr$};
+\node at (34,-36) [info] {$student.firstname$};
+\node at (95,-36) [info] {$student.lastname$};
+\node at (34,-49) [info] {$student.strasse$};
+\node at (95,-49) [info] {$student.ort$}; 
+\node at (34,-61) [info] {$student.matrikelnr$};
+\node at (95,-61) [info] {$studium.studiengangnr$};
 \end{tikzpicture}}, pages=1]{$assignment.file$}
 $if(assignment.multipage)$ % check if we need to include the rest of the document
 \includepdf[pages=$assignment.pages$]{$assignment.file$} % Include rest of document
@@ -574,7 +574,7 @@ $if(acronym)$
 $for(acronym.list)$
 	\acro{$it.id$}[$it.short$]{$it.long$}
 	$if(it.longplural)$
-	\acro{$it.id$}[$if(it.shortplural)$$it.shortplural$$else$$it.short$$endif$]{$it.longplural$}
+	\acroplural{$it.id$}[$if(it.shortplural)$$it.shortplural$$else$$it.short$$endif$]{$it.longplural$}
 	$endif$
 $endfor$
 \end{acronym}


### PR DESCRIPTION
- Fix broken acronym plurals m( 
- add more info to Readme.md and also add some Beispiel Code
- Slightly adjusted coordinates for Aufgabenstellung 